### PR TITLE
Some spi modifications and DEBUGHTTP proposing

### DIFF
--- a/TcpStack.cpp
+++ b/TcpStack.cpp
@@ -85,7 +85,8 @@ void TcpStack::handleStack(void)
 
 			if (ipCheckOk)
 			{
-				if (DEBUG) Serial.println(F("Got ARP for my IP!"));
+//SKA
+				if (DEBUGHTTP) Serial.println(F("Got ARP for my IP!"));
 				returnArp();
 			}
 		}
@@ -105,7 +106,8 @@ void TcpStack::handleStack(void)
 
 				if (icmp)
 				{
-					if (DEBUG) Serial.println(F("Got ICMP!"));
+//SKA
+					if (DEBUGHTTP) Serial.println(F("Got ICMP!"));
 					returnIcmp();
 				}
 				else
@@ -134,7 +136,8 @@ void TcpStack::handleStack(void)
 								// session exists and is closing!
 								if (m_closing)
 								{
-									if (DEBUG) Serial.println(F("closing!"));
+//SKA
+									if (DEBUGHTTP) Serial.println(F("closing!"));
 
 									// Let client know that we know
 									// it is the way it works
@@ -176,7 +179,8 @@ void TcpStack::handleStack(void)
 								}
 								else if (m_responding && !m_closing)
 								{
-									if (DEBUG) Serial.println(F("responding!"));
+//SKA
+									if (DEBUGHTTP) Serial.println(F("responding!"));
 								}
 								else if (m_closing)
 								{
@@ -295,7 +299,8 @@ void TcpStack::handleStack(void)
 
 							if (!isSession())
 							{
-								if (DEBUG) Serial.println(F("new session!"));
+//SKA
+								if (DEBUGHTTP) Serial.println(F("new session!"));
 								// new session
 								m_sessionPort = (uint)(((uint)(m_tcpData[TCP_SRC_PORT_H_P]<<8) & 0xFF00) | (m_tcpData[TCP_SRC_PORT_L_P] & 0x00FF));
 								m_seqNum.b[0] = m_tcpData[TCP_SEQ_P+3];
@@ -422,7 +427,8 @@ void TcpStack::returnIcmp(void)
 
 void TcpStack::returnSyn(void)
 {
-	if (DEBUG) Serial.println(F("Returning SYN!"));
+//SKA
+	if (DEBUGHTTP) Serial.println(F("Returning SYN!"));
 
 	// Filling send buffer
 	for (unsigned i = 0; i < DATA_SIZE; i++) m_sendData[i] = m_tcpData[i];
@@ -508,7 +514,8 @@ void TcpStack::returnSyn(void)
 
 void TcpStack::returnPush(void)
 {
-	if (DEBUG) Serial.println(F("Returning PUSH!"));
+//SKA
+	if (DEBUGHTTP) Serial.println(F("Returning PUSH!"));
 
 	// Filling send buffer
 	// for (unsigned i = 0; i < DATA_SIZE; i++) m_sendData[i] = m_tcpData[i];
@@ -630,7 +637,8 @@ void TcpStack::returnPush(void)
 
 void TcpStack::returnHttp(void) //(uchar* _buf, uint _size)
 {
-	if (DEBUG) Serial.println(F("Printing to HTTP!"));
+//SKA
+	if (DEBUGHTTP) Serial.println(F("Printing to HTTP!"));
 
 	// Filling send buffer
 	// for (unsigned i = 0; i < DATA_SIZE; i++) m_sendData[i] = m_tcpData[i];
@@ -934,7 +942,8 @@ void TcpStack::returnClose(void)
 
 void TcpStack::returnFin(void)
 {
-	if (DEBUG) Serial.println(F("Returning FIN!"));
+//SKA
+	if (DEBUGHTTP) Serial.println(F("Returning FIN!"));
 
 	// Filling send buffer
 	// for (unsigned i = 0; i < DATA_SIZE; i++) m_sendData[i] = m_tcpData[i];
@@ -1130,7 +1139,7 @@ void TcpStack::open(uint serverPort)
 	// master mode and Fosc/2 clock:
 /*	SPCR = (1<<SPE)|(1<<MSTR);
 	SPSR |= (1<<SPI2X);*/
-	SPI.begin();
+//SKA	SPI.begin();
 //--- made by SKA ---
 
 	if (DEBUGLT) { Serial.println(F("Configuring Ethernet Layer...")); }

--- a/TcpStack.h
+++ b/TcpStack.h
@@ -40,6 +40,8 @@
 #define IP_SIZE			4
 #define DEBUG			0
 #define DEBUGLT			1
+//--- made by SKA ---
+#define DEBUGHTTP		1
 #define DEBUGTST		0 // Debugging why only working with DEBUG flag on. 
 				  //now it is ok, see delay at close function
 #define ETH_ARP_LEN     	42

--- a/enc28typedef.h
+++ b/enc28typedef.h
@@ -419,15 +419,20 @@
 // (note: maximum ethernet frame length would be 1518)
 #define MAX_FRAMELEN        1500        
 
+/*--- made by SKA ---
 #define ENC28J60_CONTROL_CS                     10
 #define SPI_MOSI				11
 #define SPI_MISO				12
 #define SPI_SCK					13
+*/
+#define ENC28J60_CONTROL_CS                     SS
 
 // set CS to 0 = active
-#define CSACTIVE                                (PORTB = PORTB & 0xFB)
+//--- made by SKA ---#define CSACTIVE                                (PORTB = PORTB & 0xFB)
+#define CSACTIVE	( digitalWrite(ENC28J60_CONTROL_CS, LOW) )
 // set CS to 1 = passive
-#define CSPASSIVE                               (PORTB = PORTB | 0x04)
+//--- made by SKA ---#define CSPASSIVE                               (PORTB = PORTB | 0x04)
+#define CSPASSIVE	( digitalWrite(ENC28J60_CONTROL_CS, HIGH) )
 #define waitspi()                               while(!(SPSR&(1<<SPIF)))
 
 #endif


### PR DESCRIPTION
for newMods:
1. It's proposed to use DEBUGHTTP in TcpStack.h(cpp) files to facilitate tracking HTTP session's behaviour (from start to end) and distinguishing a debug messages from inner (hardware) events.
2. Amendments in  enc28typedef.h file are proposed for a code compatibility with other than ATmega328p uCs. It's tested on Mega2560 board (well working). Atmega328/168 use SS = 10, Atmega1280/2560 - SS = 53, Atmega32u4 - SS = 17... (look through a pins_arduino.h files in IDE). SPI_MISO, SPI_MOSI, SPI_SCK aren't used in the library at all.
3. SPI.begin() is removed from TcpStack.cpp . Please, look at https://github.com/ska-la/arduino_patches/wiki/SD_hard_atmega.patch

Thanks.
